### PR TITLE
[chat] Support text hex colors in 1.16

### DIFF
--- a/protocol/test/chat/hex_color.json
+++ b/protocol/test/chat/hex_color.json
@@ -1,0 +1,1 @@
+{"color":"#ffffff","text":"Hello"}


### PR DESCRIPTION
Minecraft has hex color support now for the text object: https://minecraft.gamepedia.com/Raw_JSON_text_format#History

This PR adds support for it here. I tested it on a live server.

I did it the simple way, if you'd prefer implementations of `Deserialize` / `Serialize` I can do that too.