### PR TITLE
Depend directly on proc_macro2 for Span

### DIFF
--- a/protocol-derive/src/lib.rs
+++ b/protocol-derive/src/lib.rs
@@ -1,11 +1,10 @@
 extern crate proc_macro;
 
 use proc_macro::TokenStream as TokenStream1;
-use proc_macro2::Ident;
 use proc_macro2::TokenStream as TokenStream2;
+use proc_macro2::{Ident, Span};
 use quote::{quote, TokenStreamExt};
 use std::iter::FromIterator;
-use syn::export::Span;
 use syn::{parse_macro_input, Data, DeriveInput, Field, Fields, Lit, Meta, NestedMeta};
 
 #[proc_macro_derive(Packet, attributes(packet))]


### PR DESCRIPTION
The latest version of syn no longer exports the Span type in the way protocol-derive expected. This means that new users will get
a compile error saying "could not find `export` in `syn`". By depending on proc_macro2 for the definition of Span, this is easily resolved.