### PR TITLE
The server status response sample field is optional

### DIFF
--- a/protocol/src/data/server_status.rs
+++ b/protocol/src/data/server_status.rs
@@ -20,6 +20,7 @@ pub struct ServerVersion {
 pub struct OnlinePlayers {
     pub max: u32,
     pub online: u32,
+    #[serde(default)]
     pub sample: Vec<OnlinePlayer>,
 }
 


### PR DESCRIPTION
This makes the `sample` field optional. This field is omitted when no players are connected to the server.